### PR TITLE
Probably fixes AI laws command

### DIFF
--- a/spacebeecommands/spacebeecommands.py
+++ b/spacebeecommands/spacebeecommands.py
@@ -211,17 +211,11 @@ class SpacebeeCommands(commands.Cog):
         if response == 0.0:
             await ctx.send("Round hasn't started yet.")
             return
-        out = []
-        for key, value in sorted(response.items()):
-            try:
-                key = int(key)
-            except ValueError:
-                continue
-            out.append(f"{key}: {value}")
-        if out:
-            await ctx.send("\n".join(out))
+        out = response['laws']
+        if isinstance(out, str):
+            await ctx.send(out)
         else:
-            await ctx.send("No AI laws.")
+            await ctx.send("Law data recieved in wrong format.")
 
     @commands.command(aliases=["hcheck"])
     @checks.admin()

--- a/spacebeecommands/spacebeecommands.py
+++ b/spacebeecommands/spacebeecommands.py
@@ -213,7 +213,10 @@ class SpacebeeCommands(commands.Cog):
             return
         out = response['laws']
         if isinstance(out, str):
-            await ctx.send(out)
+            if out:
+                await ctx.send(out)
+            else:
+                await ctx.send("No law racks with connected silicons.")
         else:
             await ctx.send("Law data recieved in wrong format.")
 


### PR DESCRIPTION
Uses the rack manager's `format_for_logs` on the game side now, so the data we get is just a bunch of text separated by newlines. Has the additional bonus of ignoring law racks with no borgs on them.

This is dependant on escaped newlines working alright in responses; I couldn't find another example of it, so if those don't work I'll have to do something more annoying (build some nested lists for laws/connected silicons, probably)

The 'wrong format' message is mostly for the period where the servers are going to be returning the wrong data; feel free to remove if you don't mind it erroring for a bit.