### PR TITLE
Prevents the bot from sending a response ahelp/mhelp on discord message reply if the replying message starts with a command prefix

### DIFF
--- a/spacebeecentcom/spacebeecentcom.py
+++ b/spacebeecentcom/spacebeecentcom.py
@@ -603,8 +603,6 @@ class SpacebeeCentcom(commands.Cog):
         reference = message.reference
         if reference is None:
             return
-        if message.content[0] == ';':
-            return
         replied_to_msg = reference.resolved
         if not isinstance(replied_to_msg, discord.Message):
             return
@@ -677,8 +675,8 @@ class SpacebeeCentcom(commands.Cog):
             return
 
         try:
-            await self.process_semicolon_asay(message)
-            await self.process_discord_replies(message)
+            if not await self.process_semicolon_asay(message):
+                await self.process_discord_replies(message)
         except:
             import traceback
 

--- a/spacebeecentcom/spacebeecentcom.py
+++ b/spacebeecentcom/spacebeecentcom.py
@@ -604,7 +604,7 @@ class SpacebeeCentcom(commands.Cog):
         if reference is None:
             return
         prefixes = await self.bot.get_valid_prefixes()
-        if message.content[0] in (prefixes + ";"):
+        if message.content[0] in (prefixes + [";"]):
             return
         replied_to_msg = reference.resolved
         if not isinstance(replied_to_msg, discord.Message):

--- a/spacebeecentcom/spacebeecentcom.py
+++ b/spacebeecentcom/spacebeecentcom.py
@@ -603,6 +603,9 @@ class SpacebeeCentcom(commands.Cog):
         reference = message.reference
         if reference is None:
             return
+        prefixes = await self.bot.get_valid_prefixes()
+        if message.content[0] in (prefixes + ";"):
+            return
         replied_to_msg = reference.resolved
         if not isinstance(replied_to_msg, discord.Message):
             return

--- a/spacebeecentcom/spacebeecentcom.py
+++ b/spacebeecentcom/spacebeecentcom.py
@@ -603,8 +603,7 @@ class SpacebeeCentcom(commands.Cog):
         reference = message.reference
         if reference is None:
             return
-        prefixes = await self.bot.get_valid_prefixes()
-        if message.content[0] in (prefixes + [";"]):
+        if message.content[0] == ';':
             return
         replied_to_msg = reference.resolved
         if not isinstance(replied_to_msg, discord.Message):


### PR DESCRIPTION
God that's wordy
Basically people keep replying to messages accidentally in `#centcom`; this creates issues when you're adding a note and accidentally send the entire note text to the person you were talking to. This PR prevents the bot from sending that message out if the triggering message starts with `;`~~or any bot prefix~~.

This hard codes `;`, as that's how it's done elsewhere in that file; I'm happy to make it a var if you'd prefer that.
Also obligatory Im Not Python Developer so feel free to bother me with anything that looks incorrect or ugly.