### PR TITLE
Lets messagestats check messages with commands in them too

### DIFF
--- a/messagecounter/messagecounter.py
+++ b/messagecounter/messagecounter.py
@@ -159,12 +159,13 @@ class MessageCounter(commands.Cog):
         await ctx.message.add_reaction("\N{White Heavy Check Mark}")
 
     @commands.Cog.listener()
-    async def on_message_without_command(self, message: discord.Message):
+    async def on_message(self, message: discord.Message):
         if (
             message.guild is None
             or await self.bot.cog_disabled_in_guild(self, message.guild)
             or not hasattr(message.author, "roles")
             or message.author.bot
+            or message.content.find("messagestats")
         ):
             return
 


### PR DESCRIPTION
Can't test myself without hosting a whole bot instance but should probably work.
The `find` string is ugly and hard-coded, not sure if there's a clean way to get the name of the cog (couldn't find one in the docs). Should work to avoid adding to counters as people check them.

# Why It's Good for the ~~Game~~ Bot
lets me see how many people have timed themselves out
