### PR TITLE
Fix stats command in spacebeecommands cog

### DIFF
--- a/spacebeecommands/spacebeecommands.py
+++ b/spacebeecommands/spacebeecommands.py
@@ -748,9 +748,7 @@ RTT: {elapsed * 1000:.2f}ms"""
         embed.add_field(name="rounds joined (total)", value=data.pop("participated"))
         embed.add_field(name="rounds joined (rp)", value=data.pop("participated_rp"))
         if "playtime" in data:
-            playtime_seconds = int(json.loads(data["playtime"])[0]["time_played"])
-            data.pop("playtime")
-            time_played = goonservers.seconds_to_hhmmss(playtime_seconds)
+            time_played = goonservers.seconds_to_hhmmss(data.pop("playtime"))
             embed.add_field(name="time played", value=time_played)
         if admin:
             last_seen_data = data.pop("last_seen")


### PR DESCRIPTION
API2 returns playtime as an int representing number of seconds played, so the json.loads call on it is no longer necessary and causes the command to error